### PR TITLE
Bug: Sidebar Naigation Arrow

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -138,4 +138,12 @@
   @media (min-width: breakpoint.$desktop) {
     display: flex;
   }
+
+  img {
+    transition: transform 0.25s ease-in-out;
+  }
+}
+
+.collapseMenuItemActive img {
+  transform: rotate(180deg);
 }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -90,7 +90,10 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              className={classNames(
+                styles.collapseMenuItem,
+                isSidebarCollapsed && styles.collapseMenuItemActive,
+              )}
             />
           </ul>
         </nav>


### PR DESCRIPTION
This PR fixes the sidebar navigation arrow of the "Collapse" button for desktop.

The behavior of the arrow will now rotate 180 when the menu is collapsed and rotate back 180 to it's normal position when open.