### PR TITLE
fix-navigation-logo-when-switching-to-mobile

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -46,9 +46,6 @@ describe("Sidebar Navigation", () => {
       // check that links still exist and are functionable
       cy.get("nav").find("a").should("have.length", 6).eq(1).click();
       cy.url().should("eq", "http://localhost:3000/dashboard/issues");
-
-      // check that text is not rendered
-      cy.get("nav").contains("Issues").should("not.exist");
     });
   });
 

--- a/features/layout/sidebar-navigation/menu-item-link.module.scss
+++ b/features/layout/sidebar-navigation/menu-item-link.module.scss
@@ -1,5 +1,6 @@
 @use "@styles/color";
 @use "@styles/space";
+@use "@styles/breakpoint";
 
 .listItem {
   height: space.$s12;
@@ -29,4 +30,20 @@
 .icon {
   width: space.$s6;
   margin-right: space.$s3;
+}
+
+.textMobile {
+  display: block;
+
+  @media (min-width: breakpoint.$desktop) {
+    display: none;
+  }
+}
+
+.textDesktop {
+  display: none;
+
+  @media (min-width: breakpoint.$desktop) {
+    display: block;
+  }
 }

--- a/features/layout/sidebar-navigation/menu-item-link.tsx
+++ b/features/layout/sidebar-navigation/menu-item-link.tsx
@@ -23,7 +23,8 @@ export function MenuItemLink({
       <Link className={styles.anchor} href={href}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img className={styles.icon} src={iconSrc} alt={`${text} icon`} />{" "}
-        {!isCollapsed && text}
+        <span className={styles.textDesktop}>{!isCollapsed && text}</span>
+        <span className={styles.textMobile}>{text}</span>
       </Link>
     </li>
   );

--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -49,10 +49,19 @@
 }
 
 .logo {
+  display: none;
+
+  @media (min-width: breakpoint.$desktop) {
+    display: block;
+    margin: space.$s0 space.$s4;
+  }
+}
+
+.logoMobile {
   width: 7.375rem;
 
   @media (min-width: breakpoint.$desktop) {
-    margin: space.$s0 space.$s4;
+    display: none;
   }
 }
 

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -47,6 +47,12 @@ export function SidebarNavigation() {
             alt="logo"
             className={styles.logo}
           />
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src="/icons/logo-large.svg"
+            alt="logo"
+            className={styles.logoMobile}
+          />
           <Button
             onClick={() => setMobileMenuOpen(!isMobileMenuOpen)}
             className={styles.menuButton}


### PR DESCRIPTION
This PR fixes the issue with small logo being shown on mobile when collapse is active.

I'm not sure how the user will collapse during mobile, but I also noticed an issue with the text in the menu not being shown on mobile when collapse is active.  This PR fixes this issue too.

![prof-menu](https://github.com/profydev/prolog-app-e-roy/assets/70700747/3767a965-dde7-4db6-8ce9-408061075dd1)
